### PR TITLE
Fixed MysqlXmlDataSet not populating column data for empty tables

### DIFF
--- a/PHPUnit/Extensions/Database/DataSet/MysqlXmlDataSet.php
+++ b/PHPUnit/Extensions/Database/DataSet/MysqlXmlDataSet.php
@@ -44,7 +44,7 @@
  */
 
 /**
- * Data set implementation for the output of mysqldump --xml -t.
+ * Data set implementation for the output of mysqldump --xml.
  *
  * @package    PHPUnit
  * @subpackage Extensions_Database_DataSet


### PR DESCRIPTION
This bug (reported by Martin Vseticka) results in data set comparisons failing for empty tables in data sets, as no column data is populated because the class currently only pulls that information from the data
