### PR TITLE
Support for PDO sqlsrv (Microsoft SQL Server)

### DIFF
--- a/PHPUnit/Extensions/Database/DB/DefaultDatabaseConnection.php
+++ b/PHPUnit/Extensions/Database/DB/DefaultDatabaseConnection.php
@@ -205,4 +205,24 @@ class PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection implements PHPUni
     {
         return $this->getMetaData()->allowsCascading();
     }
+
+    /**
+    * Disables primary keys if connection does not allow setting them otherwise
+    *
+    * @param string $tableName
+    */
+    public function disablePrimaryKeys($tableName)
+    {
+        $this->getMetaData()->disablePrimaryKeys($tableName);
+    }
+
+    /**
+    * Reenables primary keys after they have been disabled
+    *
+    * @param string $tableName
+    */
+    public function enablePrimaryKeys($tableName)
+    {
+        $this->getMetaData()->enablePrimaryKeys($tableName);
+    }
 }

--- a/PHPUnit/Extensions/Database/DB/IDatabaseConnection.php
+++ b/PHPUnit/Extensions/Database/DB/IDatabaseConnection.php
@@ -133,4 +133,18 @@ interface PHPUnit_Extensions_Database_DB_IDatabaseConnection
      * @return bool
      */
     public function allowsCascading();
+
+    /**
+    * Disables primary keys if connection does not allow setting them otherwise
+    *
+    * @param string $tableName
+    */
+    public function disablePrimaryKeys($tableName);
+
+    /**
+    * Reenables primary keys after they have been disabled
+    *
+    * @param string $tableName
+    */
+    public function enablePrimaryKeys($tableName);
 }

--- a/PHPUnit/Extensions/Database/DB/IMetaData.php
+++ b/PHPUnit/Extensions/Database/DB/IMetaData.php
@@ -102,4 +102,18 @@ interface PHPUnit_Extensions_Database_DB_IMetaData
      * @return bool
      */
     public function allowsCascading();
+
+    /**
+    * Disables primary keys if rdbms does not allow setting them otherwise
+    *
+    * @param string $tableName
+    */
+    public function disablePrimaryKeys($tableName);
+
+    /**
+    * Reenables primary keys after they have been disabled
+    *
+    * @param string $tableName
+    */
+    public function enablePrimaryKeys($tableName);
 }

--- a/PHPUnit/Extensions/Database/DB/MetaData.php
+++ b/PHPUnit/Extensions/Database/DB/MetaData.php
@@ -224,4 +224,24 @@ abstract class PHPUnit_Extensions_Database_DB_MetaData implements PHPUnit_Extens
     {
         return FALSE;
     }
+
+    /**
+    * Disables primary keys if the rdbms does not allow setting them otherwise
+    *
+    * @param string $tableName
+    */
+    public function disablePrimaryKeys($tableName)
+    {
+        return;
+    }
+
+    /**
+    * Reenables primary keys after they have been disabled
+    *
+    * @param string $tableName
+    */
+    public function enablePrimaryKeys($tableName)
+    {
+        return;
+    }
 }

--- a/PHPUnit/Extensions/Database/DB/MetaData/SqlSrv.php
+++ b/PHPUnit/Extensions/Database/DB/MetaData/SqlSrv.php
@@ -137,4 +137,36 @@ class PHPUnit_Extensions_Database_DB_MetaData_SqlSrv extends PHPUnit_Extensions_
 
         return $columnNames;
     }
+
+    /**
+    * Allow overwriting identities for the given table.
+    *
+    * @param string $tableName
+    */
+    public function disablePrimaryKeys($tableName)
+    {
+        try {
+            $query = "SET IDENTITY_INSERT $tableName ON";
+            $this->pdo->exec($query);
+        }
+        catch (PDOException $e) {
+            // ignore the error here - can happen if primary key is not an identity
+        }
+    }
+
+    /**
+    * Reenable auto creation of identities for the given table.
+    *
+    * @param string $tableName
+    */
+    public function enablePrimaryKeys($tableName)
+    {
+        try {
+            $query = "SET IDENTITY_INSERT $tableName OFF";
+            $this->pdo->exec($query);
+        }
+        catch (PDOException $e) {
+            // ignore the error here - can happen if primary key is not an identity
+        }
+    }
 }

--- a/PHPUnit/Extensions/Database/Operation/Insert.php
+++ b/PHPUnit/Extensions/Database/Operation/Insert.php
@@ -93,4 +93,12 @@ class PHPUnit_Extensions_Database_Operation_Insert extends PHPUnit_Extensions_Da
         }
         return $args;
     }
+
+    protected function disablePrimaryKeys(PHPUnit_Extensions_Database_DataSet_ITableMetaData $databaseTableMetaData, PHPUnit_Extensions_Database_DataSet_ITable $table, PHPUnit_Extensions_Database_DB_IDatabaseConnection $connection)
+    {
+        if (count($databaseTableMetaData->getPrimaryKeys())) {
+            return TRUE;
+        }
+        return FALSE;
+    }
 }

--- a/PHPUnit/Extensions/Database/Operation/RowBased.php
+++ b/PHPUnit/Extensions/Database/Operation/RowBased.php
@@ -72,6 +72,18 @@ abstract class PHPUnit_Extensions_Database_Operation_RowBased implements PHPUnit
     protected abstract function buildOperationArguments(PHPUnit_Extensions_Database_DataSet_ITableMetaData $databaseTableMetaData, PHPUnit_Extensions_Database_DataSet_ITable $table, $row);
 
     /**
+    * Allows an operation to disable primary keys if necessary.
+    *
+    * @param PHPUnit_Extensions_Database_DataSet_ITableMetaData $databaseTableMetaData
+    * @param PHPUnit_Extensions_Database_DataSet_ITable $table
+    * @param PHPUnit_Extensions_Database_DB_IDatabaseConnection $connection
+    */
+    protected function disablePrimaryKeys(PHPUnit_Extensions_Database_DataSet_ITableMetaData $databaseTableMetaData, PHPUnit_Extensions_Database_DataSet_ITable $table, PHPUnit_Extensions_Database_DB_IDatabaseConnection $connection)
+    {
+        return FALSE;
+    }
+
+    /**
      * @param PHPUnit_Extensions_Database_DB_IDatabaseConnection $connection
      * @param PHPUnit_Extensions_Database_DataSet_IDataSet $dataSet
      */
@@ -85,9 +97,14 @@ abstract class PHPUnit_Extensions_Database_Operation_RowBased implements PHPUnit
             /* @var $table PHPUnit_Extensions_Database_DataSet_ITable */
             $databaseTableMetaData = $databaseDataSet->getTableMetaData($table->getTableMetaData()->getTableName());
             $query                 = $this->buildOperationQuery($databaseTableMetaData, $table, $connection);
+            $disablePrimaryKeys    = $this->disablePrimaryKeys($databaseTableMetaData, $table, $connection);
 
             if ($query === FALSE && $table->getRowCount() > 0) {
                 throw new PHPUnit_Extensions_Database_Operation_Exception($this->operationName, '', array(), $table, "Rows requested for insert, but no columns provided!");
+            }
+
+            if ($disablePrimaryKeys) {
+                $connection->disablePrimaryKeys($databaseTableMetaData->getTableName());
             }
 
             $statement = $connection->getConnection()->prepare($query);
@@ -105,6 +122,10 @@ abstract class PHPUnit_Extensions_Database_Operation_RowBased implements PHPUnit
                       $this->operationName, $query, $args, $table, $e->getMessage()
                     );
                 }
+            }
+
+            if ($disablePrimaryKeys) {
+                $connection->enablePrimaryKeys($databaseTableMetaData->getTableName());
             }
         }
     }

--- a/PHPUnit/Extensions/Database/Operation/Update.php
+++ b/PHPUnit/Extensions/Database/Operation/Update.php
@@ -66,10 +66,10 @@ class PHPUnit_Extensions_Database_Operation_Update extends PHPUnit_Extensions_Da
         $setStatement   = 'SET ' . implode(', ', $this->buildPreparedColumnArray($columns, $connection));
 
         $query = "
-			UPDATE {$connection->quoteSchemaObject($table->getTableMetaData()->getTableName())}
-			{$setStatement}
-			{$whereStatement}
-		";
+            UPDATE {$connection->quoteSchemaObject($table->getTableMetaData()->getTableName())}
+            {$setStatement}
+            {$whereStatement}
+        ";
 
         return $query;
     }
@@ -86,5 +86,13 @@ class PHPUnit_Extensions_Database_Operation_Update extends PHPUnit_Extensions_Da
         }
 
         return $args;
+    }
+
+    protected function disablePrimaryKeys(PHPUnit_Extensions_Database_DataSet_ITableMetaData $databaseTableMetaData, PHPUnit_Extensions_Database_DataSet_ITable $table, PHPUnit_Extensions_Database_DB_IDatabaseConnection $connection)
+    {
+        if (count($databaseTableMetaData->getPrimaryKeys())) {
+            return TRUE;
+        }
+        return FALSE;
     }
 }


### PR DESCRIPTION
SQL Server requires that you run "SET IDENTITY_INSERT ON" before executing INSERTS that manually set a value for an identity column (like auto increment on mysql). I wasn't entirely sure where to best place the logic for that, so feel free to alter that.

The new SqlSrv.php file states it exists since version 1.0.1 you might want to adjust that to whatever you pick.
