### PR TITLE
Fix for issue #11 (https://github.com/sebastianbergmann/dbunit/issues#issue/11)

### DIFF
--- a/PHPUnit/Extensions/Database/DataSet/QueryTable.php
+++ b/PHPUnit/Extensions/Database/DataSet/QueryTable.php
@@ -154,7 +154,24 @@ class PHPUnit_Extensions_Database_DataSet_QueryTable extends PHPUnit_Extensions_
         if ($this->tableMetaData === NULL)
         {
             $this->loadData();
-            $this->tableMetaData = new PHPUnit_Extensions_Database_DataSet_DefaultTableMetaData($this->tableName, array_keys($this->data[0]));
+
+            // if some rows are in the table
+            $columns = array();
+            if (isset($this->data[0]))
+                // get column names from data
+                $columns = array_keys($this->data[0]);
+            else {
+                // if no rows found, get column names from database
+                $pdoStatement = $this->databaseConnection->getConnection()->prepare("SELECT column_name FROM information_schema.COLUMNS WHERE table_schema=:schema AND table_name=:table");
+                $pdoStatement->execute(array(
+                    "table"        => $this->tableName,
+                    "schema"    => $this->databaseConnection->getSchema()
+                ));
+
+                $columns = $pdoStatement->fetchAll(PDO::FETCH_COLUMN, 0);
+            }
+            // create metadata
+            $this->tableMetaData = new PHPUnit_Extensions_Database_DataSet_DefaultTableMetaData($this->tableName, $columns);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/sebastianbergmann/dbunit/issues#issue/11

QueryTable throws error if table is empty due to table column names being taken 
from QueryTable::data array keys.

This fix does the following: if data is empty, column names being fetched from database
table structure.

P.S.: This is my first fork and pull request ever on github... eh... i hope i didn't mess up :)
