### PR TITLE
assertEquals() equates NULL and empty values

### DIFF
--- a/PHPUnit/Extensions/Database/DataSet/AbstractTable.php
+++ b/PHPUnit/Extensions/Database/DataSet/AbstractTable.php
@@ -160,7 +160,9 @@ class PHPUnit_Extensions_Database_DataSet_AbstractTable implements PHPUnit_Exten
         for ($i = 0; $i < $rowCount; $i++) {
             foreach ($columns as $columnName) {
                 if ($this->getValue($i, $columnName) !== $other->getValue($i, $columnName)) {
-                    throw new Exception("Expected value of {$this->getValue($i, $columnName)} for row {$i} column {$columnName}, has a value of {$other->getValue($i, $columnName)}");
+					$expectedValue = ( is_null($this->getValue($i, $columnName)) ) ? 'NULL' : $this->getValue($i, $columnName);
+					$actualValue = ( is_null($other->getValue($i, $columnName)) ) ? 'NULL' : $other->getValue($i, $columnName);
+                    throw new Exception("Expected value of {$expectedValue} for row {$i} column {$columnName}, has a value of {$actualValue}");
                 }
             }
         }

--- a/PHPUnit/Extensions/Database/DataSet/ReplacementTable.php
+++ b/PHPUnit/Extensions/Database/DataSet/ReplacementTable.php
@@ -177,7 +177,9 @@ class PHPUnit_Extensions_Database_DataSet_ReplacementTable implements PHPUnit_Ex
         for ($i = 0; $i < $rowCount; $i++) {
             foreach ($columns as $columnName) {
                 if ($this->getValue($i, $columnName) !== $other->getValue($i, $columnName)) {
-                    throw new Exception("Expected value of {$this->getValue($i, $columnName)} for row {$i} column {$columnName}, has a value of {$other->getValue($i, $columnName)}");
+					$expectedValue = ( is_null($this->getValue($i, $columnName)) ) ? 'NULL' : $this->getValue($i, $columnName);
+					$actualValue = ( is_null($other->getValue($i, $columnName)) ) ? 'NULL' : $other->getValue($i, $columnName);
+                    throw new Exception("Expected value of {$expectedValue} for row {$i} column {$columnName}, has a value of {$actualValue}");
                 }
             }
         }


### PR DESCRIPTION
The assertEquals method in PHPUnit_Extensions_Database_DataSet_ReplacementTable and PHPUnit_Extensions_Database_DataSet_AbstractTable performs a not equal != comparison between $this->getValue($i, $columnName) and $other->getValue($i, $columnName). This leads to NULL and empty character fields, or int(0), being considered equivalent. Performing a not identical comparison !== here differentiates NULL from other values.
