### PR TITLE
Query in getRowCount() is never executed

### DIFF
--- a/PHPUnit/Extensions/Database/DB/DefaultDatabaseConnection.php
+++ b/PHPUnit/Extensions/Database/DB/DefaultDatabaseConnection.php
@@ -164,7 +164,7 @@ class PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection implements PHPUni
      *
      * @param string $tableName
      * @param string $whereClause
-     * @param int
+     * @return int
      */
     public function getRowCount($tableName, $whereClause = NULL)
     {
@@ -173,6 +173,8 @@ class PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection implements PHPUni
         if (isset($whereClause)) {
             $query .= " WHERE {$whereClause}";
         }
+
+        return (int) $this->connection->query($query)->fetchColumn();
     }
 
     /**


### PR DESCRIPTION
This patch adds code that actually runs the generated query in the getRowCount() method
