### PR TITLE
Check for simplexml being loaded before calling @simplexml_load_file.

### DIFF
--- a/PHPUnit/Extensions/Database/DataSet/AbstractXmlDataSet.php
+++ b/PHPUnit/Extensions/Database/DataSet/AbstractXmlDataSet.php
@@ -73,6 +73,10 @@ abstract class PHPUnit_Extensions_Database_DataSet_AbstractXmlDataSet extends PH
      */
     public function __construct($xmlFile)
     {
+        if (!function_exists('simplexml_load_file')) {
+            throw new RuntimeException("simplexml_load_file does not exist - is simplexml installed?");
+        }
+        
         if (!is_file($xmlFile)) {
             throw new InvalidArgumentException(
               "Could not find xml file: {$xmlFile}"


### PR DESCRIPTION
It is a fatal error to call undefined functions. When such calls are
preceded with @, php dies without any feedback as to the cause of
the error. Add a check for simplexml_load_file's existence before
calling it with @.
