### PR TITLE
Fix for issue #34

### DIFF
--- a/PHPUnit/Extensions/Database/DB/DefaultDatabaseConnection.php
+++ b/PHPUnit/Extensions/Database/DB/DefaultDatabaseConnection.php
@@ -173,6 +173,8 @@ class PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection implements PHPUni
         if (isset($whereClause)) {
             $query .= " WHERE {$whereClause}";
         }
+
+        return (int) $this->connection->query($query)->fetchColumn();
     }
 
     /**

--- a/Tests/DB/DefaultDatabaseConnectionTest.php
+++ b/Tests/DB/DefaultDatabaseConnectionTest.php
@@ -1,0 +1,27 @@
+<?php
+class DefaultDatabaseConnectionTest extends PHPUnit_Framework_TestCase
+{
+    protected $db;
+
+    protected function setUp()
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec('CREATE TABLE test (field1 VARCHAR(100))');
+    }
+
+    public function testRowCountForEmptyTableReturnsZero()
+    {
+        $conn = new PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection($this->db);
+        $this->assertEquals(0, $conn->getRowCount('test'));
+    }
+
+    public function testRowCountForTableWithTwoRowsReturnsTwo()
+    {
+        $this->db->exec('INSERT INTO test (field1) VALUES (\'foobar\')');
+        $this->db->exec('INSERT INTO test (field1) VALUES (\'foobarbaz\')');
+
+        $conn = new PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection($this->db);
+        $this->assertEquals(2, $conn->getRowCount('test'));
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
     <testsuite name="PHPUnit">
       <directory suffix="Test.php">Tests/DataSet</directory>
       <directory suffix="Test.php">Tests/Operation</directory>
+      <directory suffix="Test.php">Tests/DB</directory>
     </testsuite>
   </testsuites>
 


### PR DESCRIPTION
PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection::getRowCount does not return anything.

Modified method to return the row count. Added tests for this method.
