### PR TITLE
Changed the ReplacementTable class, method getReplacedValue to handle null values.

### DIFF
--- a/PHPUnit/Extensions/Database/DataSet/ReplacementTable.php
+++ b/PHPUnit/Extensions/Database/DataSet/ReplacementTable.php
@@ -235,7 +235,7 @@ class PHPUnit_Extensions_Database_DataSet_ReplacementTable implements PHPUnit_Ex
             return $this->fullReplacements[$value];
         }
 
-        else if (count($this->subStrReplacements)) {
+        else if (count($this->subStrReplacements) && isset($value)) {
             return str_replace(array_keys($this->subStrReplacements), array_values($this->subStrReplacements), $value);
         }
 


### PR DESCRIPTION
Add check to the ReplacementTable class, method getReplacedValue to check if the value isset before doing the str_replace on the value.  This was causing a problem when the value should be set to null and the str_replace is returning an empty string.

Thank you,
Jason Evans
