### PR TITLE
fixed 'Cannot redeclare echoln()' error

### DIFF
--- a/PHPUnit/Extensions/Database/DataSet/YamlDataSet.php
+++ b/PHPUnit/Extensions/Database/DataSet/YamlDataSet.php
@@ -42,7 +42,10 @@
  * @since      File available since Release 1.0.0
  */
 
-require_once 'SymfonyComponents/YAML/sfYaml.php';
+if (!class_exists('sfYaml', false))
+{
+    require_once 'SymfonyComponents/YAML/sfYaml.php';
+}
 
 /**
  * Creates CsvDataSets.


### PR DESCRIPTION
I cannot test my project, because in my bootstrap file sfYaml is already loaded (it's part of the project I want to test). This makes the database test cases fail.

Please include this patch so that I don't have to fiddle with the locally installed PHPUnit.
