### PR TITLE
Removed static keyword

### DIFF
--- a/PHPUnit/Extensions/Database/TestCase.php
+++ b/PHPUnit/Extensions/Database/TestCase.php
@@ -255,7 +255,7 @@ abstract class PHPUnit_Extensions_Database_TestCase extends PHPUnit_Framework_Te
      * @param int $expected Expected amount of rows in the table
      * @param string $message Optional message
      */
-    public static function assertTableRowCount($tableName, $expected, $message = '')
+    public function assertTableRowCount($tableName, $expected, $message = '')
     {
         $constraint = new PHPUnit_Extensions_Database_Constraint_TableRowCount($tableName, $expected);
         $actual = $this->getConnection()->getRowCount($tableName);


### PR DESCRIPTION
This assertion has never worked since it needs to fetch the current connection via `$this`. By making the assertion non-static it works as expected. The initial commit of the feature is by none other than ... me. :/
