### PR TITLE
Composer fixes: include path and branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,6 @@
             "role": "lead"
         }
     ],
-    "version": "1.2.0RC1",
-    "time": "2012-08-18",
     "support": {
         "issues": "https://github.com/sebastianbergmann/dbunit/issues",
         "irc": "irc://irc.freenode.net/phpunit"
@@ -32,8 +30,7 @@
         "ext-spl": "*"
     },
     "bin": [
-        "dbunit.php",
-        "dbunit.bat"
+        "dbunit.php"
     ],
     "config": {
         "bin-dir": "bin"
@@ -43,7 +40,13 @@
             "PHPUnit/Extentions/Database/Autoload.php"
         ]
     },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.2.x-dev"
+        }
+    },
     "include-path": [
-        ""
+        "",
+        "../../symfony/yaml/"
     ]
 }

--- a/package-composer.json
+++ b/package-composer.json
@@ -14,10 +14,15 @@
         "files": ["PHPUnit/Extentions/Database/Autoload.php"]
     },
     "include_path": [
-        ""
+        "",
+        "../../symfony/yaml/"
     ],
     "bin": [
-        "dbunit.php",
-        "dbunit.bat"
-    ]
+        "dbunit.php"
+    ],
+    "branch-alias": {
+        "dev-master": "1.2.x-dev"
+    },
+    "version": false,
+    "time": false
 }


### PR DESCRIPTION
Updated the `package2composer` config file to reflect options in Conductor 1.0.4 (branch-alias, relying on Git for version and release date). Also added necessary include-path for local YAML, which I erroneously removed in the switch from Symfony1 YAML to Symfony2 YAML.
