### PR TITLE
composer support now uses classmap autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "bin-dir": "bin"
     },
     "autoload": {
-        "files": [
+        "classmap": [
+            "PHPUnit/"
         ]
     },
     "extra": {

--- a/package-composer.json
+++ b/package-composer.json
@@ -11,7 +11,7 @@
         "irc": "irc://irc.freenode.net/phpunit"
     },
     "autoload": {
-        "files": []
+        "classmap": [ "PHPUnit/" ]
     },
     "include_path": [
         "",


### PR DESCRIPTION
package2composer should do the right thing with this change in dev and stable branches.
