### PR TITLE
Bug fix: Fatal error:  Cannot call abstract method PHPUnit_Extensions_Da...

### DIFF
--- a/PHPUnit/Extensions/Database/TestCase.php
+++ b/PHPUnit/Extensions/Database/TestCase.php
@@ -258,7 +258,7 @@ abstract class PHPUnit_Extensions_Database_TestCase extends PHPUnit_Framework_Te
     public function assertTableRowCount($tableName, $expected, $message = '')
     {
         $constraint = new PHPUnit_Extensions_Database_Constraint_TableRowCount($tableName, $expected);
-        $actual = self::getConnection()->getRowCount($tableName);
+        $actual = $this->getConnection()->getRowCount($tableName);
 
         self::assertThat($actual, $constraint, $message);
     }


### PR DESCRIPTION
Fixes bug:
Fatal error:  Cannot call abstract method PHPUnit_Extensions_Database_TestCase::getConnection() in /usr/share/pear/PHPUnit/Extensions/Database/TestCase.php on line 261
