### PR TITLE
Fix loading PostgreSQL primary keys

### DIFF
--- a/PHPUnit/Extensions/Database/DB/MetaData/PgSQL.php
+++ b/PHPUnit/Extensions/Database/DB/MetaData/PgSQL.php
@@ -150,7 +150,8 @@ class PHPUnit_Extensions_Database_DB_MetaData_PgSQL extends PHPUnit_Extensions_D
             FROM
                 INFORMATION_SCHEMA.KEY_COLUMN_USAGE as KCU
             LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS as TC
-                ON TC.TABLE_NAME = KCU.TABLE_NAME
+                ON TC.TABLE_NAME = KCU.TABLE_NAME AND
+                TC.CONSTRAINT_NAME = KCU.CONSTRAINT_NAME
             WHERE
                 TC.CONSTRAINT_TYPE = 'PRIMARY KEY' AND
                 TC.TABLE_NAME = ? AND


### PR DESCRIPTION
It has been broken for quite a long time when somebody made a change to this file (not original developer), so I have finally decided to fix it.
Without my patch, this method will return unique constraints and foreign keys along with actual primary key as if they all were primary keys, which is obviously not true. Then certain commands will fail, as they rely on primary keys (e.g. UPDATE). It's simply a bad join.
After the change, only actual primary key constraints are returned. Tested with PostgreSQL 9.1.
