### PR TITLE
 Add null dataset for database extension

### DIFF
--- a/PHPUnit/Extensions/Database/Autoload.php
+++ b/PHPUnit/Extensions/Database/Autoload.php
@@ -73,6 +73,7 @@ spl_autoload_register(
             'phpunit_extensions_database_dataset_itableiterator' => '/Extensions/Database/DataSet/ITableIterator.php',
             'phpunit_extensions_database_dataset_itablemetadata' => '/Extensions/Database/DataSet/ITableMetaData.php',
             'phpunit_extensions_database_dataset_mysqlxmldataset' => '/Extensions/Database/DataSet/MysqlXmlDataSet.php',
+	    	'phpunit_extensions_database_dataset_nulldataset' => '/Extensions/Database/DataSet/NullDataSet.php',
             'phpunit_extensions_database_dataset_persistors_abstract' => '/Extensions/Database/DataSet/Persistors/Abstract.php',
             'phpunit_extensions_database_dataset_persistors_factory' => '/Extensions/Database/DataSet/Persistors/Factory.php',
             'phpunit_extensions_database_dataset_persistors_flatxml' => '/Extensions/Database/DataSet/Persistors/FlatXml.php',

--- a/PHPUnit/Extensions/Database/DataSet/NullDataSet.php
+++ b/PHPUnit/Extensions/Database/DataSet/NullDataSet.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2002-2013, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    DbUnit
+ * @author     mManishTrivedi <manish.tech2@gmail.com>
+ * @copyright  2002-2013 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 1.0.0
+ */
+
+/**
+ *	This class represents a null dataset.
+ *
+ * @package    DbUnit
+ * @author     mManishTrivedi <manish.tech2@gmail.com>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @version    Release: 1.2.3
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 1.0.0
+ */
+
+class PHPUnit_Extensions_Database_DataSet_NullDataSet extends PHPUnit_Extensions_Database_DataSet_AbstractDataSet 
+{
+    /**
+     * @var array
+     */
+    protected $tables = array();
+ 
+    
+    protected function createIterator($reverse = FALSE)
+    {
+        return $this->tables;
+    }
+
+}


### PR DESCRIPTION
It will useful when we don't have any data-set for testing of database. You can return **null data-set** object on getdataset() method during setup.
