### PR TITLE
Fix getTableNames bug on empty database

### DIFF
--- a/PHPUnit/Extensions/Database/DB/MetaData/Sqlite.php
+++ b/PHPUnit/Extensions/Database/DB/MetaData/Sqlite.php
@@ -79,6 +79,8 @@ class PHPUnit_Extensions_Database_DB_MetaData_Sqlite extends PHPUnit_Extensions_
 
         $result = $this->pdo->query($query);
 
+        $tableNames = array();
+
         while ($tableName = $result->fetchColumn(0)) {
             $tableNames[] = $tableName;
         }


### PR DESCRIPTION
When function `getTableNames` is called on a empty database, an error occured `Undefined variable: tableNames`
