### PR TITLE
Fixing an issue reported on StackOverflow

### DIFF
--- a/Samples/BankAccountDB/BankAccountCompositeTest.php
+++ b/Samples/BankAccountDB/BankAccountCompositeTest.php
@@ -70,7 +70,7 @@ class BankAccountCompositeTest extends PHPUnit_Framework_TestCase
      */
     protected function getDatabaseTester()
     {
-        $connection = new PHPUnit_Extensions_Database_DB_DefaultConnection($this->pdo, 'sqlite');
+        $connection = new PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection($this->pdo, 'sqlite');
         $tester = new PHPUnit_Extensions_Database_DefaultTester($connection);
         $tester->setSetUpOperation(PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT());
         $tester->setTearDownOperation(PHPUnit_Extensions_Database_Operation_Factory::NONE());


### PR DESCRIPTION
On StackOverflow someone was using the BankAccountCompositeTest as an example for composite DB testing but stumbled time after time against the error `PHPUnit_Extensions_Database_DB_DefaultConnection not found`.

A simple check of the filesystem would have made it clear that the class name is different, it wouldn't hurt to update the documentation and examples so people get a smooth experience testing databases.

The StackOverflow report can be found here: http://stackoverflow.com/questions/20280621/how-to-test-with-dbunit-using-composite/
