### PR TITLE
Added Undefined offset test for reading XmlDataSet

### DIFF
--- a/PHPUnit/Extensions/Database/DataSet/XmlDataSet.php
+++ b/PHPUnit/Extensions/Database/DataSet/XmlDataSet.php
@@ -96,9 +96,11 @@ class PHPUnit_Extensions_Database_DataSet_XmlDataSet extends PHPUnit_Extensions_
             foreach ($tableElement->xpath('./row') as $rowElement) {
                 $rowValues = array();
                 $index     = 0;
+                $numOfTableInstanceColumns = count($tableInstanceColumns);
 
                 foreach ($rowElement->children() as $columnValue) {
-                    if ($index >= count($tableInstanceColumns)) {
+                    
+                    if ($index >= $numOfTableInstanceColumns) {
                         throw new PHPUnit_Extensions_Database_Exception("More row values defined as columns exists.");
                     }
                     switch ($columnValue->getName()) {


### PR DESCRIPTION
If you define n columns and add n + 1 rows it will generate an undefined offset error.

Example .xml file:

<?xml version="1.0" encoding="UTF-8"?>
<dataset>
    <table name="drop_chat_file_repository">
        <column>id</column>
        <row>
            <value>1</value>
            <value>1</value>
        </row>
    </table>
</dataset>

Therefore a check is necessary. Because $rowElement->children()->count() didn't work for me properly it was necessary to test the index in the foreach instead of testing it beforehand with something like 'if ($rowElement->children()->count() >= count($tableInstanceColumns) {}
