### PR TITLE
Added parent constructor call to constraints. Fixed the TableRowCountTes...

### DIFF
--- a/PHPUnit/Extensions/Database/Constraint/DataSetIsEqual.php
+++ b/PHPUnit/Extensions/Database/Constraint/DataSetIsEqual.php
@@ -72,6 +72,7 @@ class PHPUnit_Extensions_Database_Constraint_DataSetIsEqual extends PHPUnit_Fram
      */
     public function __construct(PHPUnit_Extensions_Database_DataSet_IDataSet $value)
     {
+        parent::__construct();
         $this->value = $value;
     }
 

--- a/PHPUnit/Extensions/Database/Constraint/TableIsEqual.php
+++ b/PHPUnit/Extensions/Database/Constraint/TableIsEqual.php
@@ -72,6 +72,7 @@ class PHPUnit_Extensions_Database_Constraint_TableIsEqual extends PHPUnit_Framew
      */
     public function __construct(PHPUnit_Extensions_Database_DataSet_ITable $value)
     {
+        parent::__construct();
         $this->value = $value;
     }
 

--- a/PHPUnit/Extensions/Database/Constraint/TableRowCount.php
+++ b/PHPUnit/Extensions/Database/Constraint/TableRowCount.php
@@ -68,10 +68,12 @@ class PHPUnit_Extensions_Database_Constraint_TableRowCount extends PHPUnit_Frame
     /**
      * Creates a new constraint.
      *
-     * @param int $expected
+     * @param $tableName
+     * @param $value
      */
     public function __construct($tableName, $value)
     {
+        parent::__construct();
         $this->tableName = $tableName;
         $this->value = $value;
     }

--- a/Tests/Constraint/TableRowCountTest.php
+++ b/Tests/Constraint/TableRowCountTest.php
@@ -55,16 +55,18 @@ class Extensions_Database_Constraint_TableRowCountTest extends PHPUnit_Framework
     public function testConstraint()
     {
         $constraint = new PHPUnit_Extensions_Database_Constraint_TableRowCount('name', 42);
-        $this->assertTrue($constraint->evaluate(42));
-        $this->assertFalse($constraint->evaluate(24));
+
+        $this->assertTrue($constraint->evaluate(42, '', true));
+        $this->assertFalse($constraint->evaluate(24, '', true));
         $this->assertEquals('is equal to expected row count 42', $constraint->toString());
 
         try {
-            $constraint->fail(24, '');
-        }
-
-        catch (PHPUnit_Framework_ExpectationFailedException $e) {
-            $this->assertEquals('Failed asserting that table "name" has 42 rows (actual row count: 24)', $e->getMessage());
+            $this->assertThat(24, $constraint, '');
+        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertEquals(
+                'Failed asserting that 24 is equal to expected row count 42.',
+                $e->getMessage()
+            );
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,7 @@
 
   <testsuites>
     <testsuite name="PHPUnit">
+      <directory suffix="Test.php">Tests/Constraint</directory>
       <directory suffix="Test.php">Tests/DataSet</directory>
       <directory suffix="Test.php">Tests/Operation</directory>
       <directory suffix="Test.php">Tests/DB</directory>


### PR DESCRIPTION
...t and added constraint tests to PHPUnit config.

Hi,
a parent constructor call was missing in the DBUnit constraints. This was throwing a PHP Fatal Error when $constraint->evaluate failed.

The test didn't show this fatal, because the test wasn't even executed and also already failed on some lines before. I added the test to the PHPUnit config and adjusted it.
