### PR TITLE
Change array_merge to array_replace in order to permit numeric keys

### DIFF
--- a/PHPUnit/Extensions/Database/DataSet/DefaultTable.php
+++ b/PHPUnit/Extensions/Database/DataSet/DefaultTable.php
@@ -74,7 +74,7 @@ class PHPUnit_Extensions_Database_DataSet_DefaultTable extends PHPUnit_Extension
      */
     public function addRow($values = array())
     {
-        $this->data[] = array_merge(
+        $this->data[] = array_replace(
           array_fill_keys($this->getTableMetaData()->getColumns(), NULL),
           $values
         );


### PR DESCRIPTION
It's an edge case, but I've got a particular scenario where I'm using integers for column names in a database table. I need to make sure the table is being populated correctly, so as normal I create one dataset from the database and one from a file, then get the tables and use `$this->assertTablesEqual()`. The problem is that `DefaultTable::addRow()` incorrectly sets the value of all columns with integer names to NULL. It happens to both real and expected datasets, so regardless of actual values in those columns, the tests always pass.

The problem occurs due to the use of `array_merge()`, which overwrites NULL values where keys are strings, but does not if keys are numeric. I've changed that to `array_replace()`, which I believe is the desired behavior to begin with, and which causes all my tests to work again.
