### PR TITLE
Remove bin from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .idea
 .vagrant
-bin
 build/api
 build/code-browser
 build/coverage


### PR DESCRIPTION
This is preventing composer/bin from being committed into larger repositories. This should be removed, or slashes should be added.