### PR TITLE
Added the ArrayDataSet as mentioned in the documentation.

### DIFF
--- a/PHPUnit/Extensions/Database/DataSet/ArrayDataSet.php
+++ b/PHPUnit/Extensions/Database/DataSet/ArrayDataSet.php
@@ -26,6 +26,19 @@ class PHPUnit_Extensions_Database_DataSet_ArrayDataSet extends PHPUnit_Extension
     protected $tables = array();
 
     /**
+     * Constructor to build a new ArrayDataSet with the given array.
+     * The array parameter is an associative array of tables where the key is
+     * the table name and the value an array of rows. Each row is an associative
+     * array by itself with keys representing the field names and the values the
+     * actual data.
+     * For example:
+     * array(
+     *     "addressbook" => array(
+     *         array("id" => 1, "name" => "...", "address" => "..."),
+     *         array("id" => 2, "name" => "...", "address" => "...")
+     *     )
+     * )
+     *
      * @param array $data
      */
     public function __construct(array $data)

--- a/PHPUnit/Extensions/Database/DataSet/ArrayDataSet.php
+++ b/PHPUnit/Extensions/Database/DataSet/ArrayDataSet.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * This file is part of DBUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Implements the basic functionality of data sets using a PHP array.
+ *
+ * @package    DbUnit
+ * @author     Richard Brinkman <richardbrinkman@hotmail.com>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @version    Release: @package_version@
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 1.3.2
+ */
+class PHPUnit_Extensions_Database_DataSet_ArrayDataSet extends PHPUnit_Extensions_Database_DataSet_AbstractDataSet
+{
+    /**
+     * @var array
+     */
+    protected $tables = array();
+
+    /**
+     * @param array $data
+     */
+    public function __construct(array $data)
+    {
+        foreach ($data AS $tableName => $rows) {
+            $columns = array();
+            if (isset($rows[0])) {
+                $columns = array_keys($rows[0]);
+            }
+
+            $metaData = new PHPUnit_Extensions_Database_DataSet_DefaultTableMetaData($tableName, $columns);
+            $table = new PHPUnit_Extensions_Database_DataSet_DefaultTable($metaData);
+
+            foreach ($rows AS $row) {
+                $table->addRow($row);
+            }
+            $this->tables[$tableName] = $table;
+        }
+    }
+
+    protected function createIterator($reverse = FALSE)
+    {
+        return new PHPUnit_Extensions_Database_DataSet_DefaultTableIterator($this->tables, $reverse);
+    }
+
+    public function getTable($tableName)
+    {
+        if (!isset($this->tables[$tableName])) {
+            throw new InvalidArgumentException("$tableName is not a table in the current database.");
+        }
+
+        return $this->tables[$tableName];
+    }
+}
+?>

--- a/PHPUnit/Extensions/Database/TestCase.php
+++ b/PHPUnit/Extensions/Database/TestCase.php
@@ -112,6 +112,28 @@ abstract class PHPUnit_Extensions_Database_TestCase extends PHPUnit_Framework_Te
     }
 
     /**
+     * Creates a new ArrayDataSet with the given array.
+     * The array parameter is an associative array of tables where the key is
+     * the table name and the value an array of rows. Each row is an associative
+     * array by itself with keys representing the field names and the values the
+     * actual data.
+     * For example:
+     * array(
+     *     "addressbook" => array(
+     *         array("id" => 1, "name" => "...", "address" => "..."),
+     *         array("id" => 2, "name" => "...", "address" => "...")
+     *     )
+     * )
+     *
+     * @param array $data
+     * @return PHPUnit_Extensions_Database_DataSet_ArrayDataSet
+     */
+    protected function createArrayDataSet(array $data)
+    {
+        return new PHPUnit_Extensions_Database_DataSet_ArrayDataSet($data);
+    }
+
+    /**
      * Creates a new FlatXmlDataSet with the given $xmlFile. (absolute path.)
      *
      * @param string $xmlFile


### PR DESCRIPTION
In the [documentation](https://phpunit.de/manual/current/en/database.html#database.array-dataset) on the website, a very handy extension is described: the ArrayDataSet. It's very usefull and should be included in the source and not only in the documentation. The documentation also mentioned that it is not implemented (yet). If this pull request got accepted, that remark (and the implementation of ArrayDataSet) can be removed.
The file is a straightforward copy/paste. I only added the usual comment header and changed the name of the class.