### PR TITLE
Pass LIBXML_PARSEHUGE flag when loading xml file

### DIFF
--- a/PHPUnit/Extensions/Database/DataSet/AbstractXmlDataSet.php
+++ b/PHPUnit/Extensions/Database/DataSet/AbstractXmlDataSet.php
@@ -46,7 +46,7 @@ abstract class PHPUnit_Extensions_Database_DataSet_AbstractXmlDataSet extends PH
         }
 
         $libxmlErrorReporting  = libxml_use_internal_errors(TRUE);
-        $this->xmlFileContents = simplexml_load_file($xmlFile);
+        $this->xmlFileContents = simplexml_load_file($xmlFile, 'SimpleXMLElement', LIBXML_COMPACT | LIBXML_PARSEHUGE);
 
         if (!$this->xmlFileContents) {
             $message = '';


### PR DESCRIPTION
Could we include this in mainstream?  I'm getting error when loading big xml files:
`xmlSAX2Characters: huge text nodeExtra content at the end of the document`

According to [this](http://stackoverflow.com/questions/14950589/simplexml-load-string-errors-on-big-files-occur-on-one-system-but-not-another#15010460) thread it seems like there is a bug in libxml library.

Thanks.