### PR TITLE
Pass YAML contents to Yaml::parse

### DIFF
--- a/PHPUnit/Extensions/Database/DataSet/SymfonyYamlParser.php
+++ b/PHPUnit/Extensions/Database/DataSet/SymfonyYamlParser.php
@@ -21,6 +21,6 @@
 class PHPUnit_Extensions_Database_DataSet_SymfonyYamlParser implements PHPUnit_Extensions_Database_DataSet_IYamlParser {
 
     public function parseYaml($yamlFile) {
-        return Symfony\Component\Yaml\Yaml::parse($yamlFile);
+        return Symfony\Component\Yaml\Yaml::parse(file_get_contents($yamlFile));
     }
 }


### PR DESCRIPTION
Make the call compatible with future Symfony version, and avoid
E_USER_DEPRECATED as thrown by the current 2.7.0-beta2:

The ability to pass file names to the Symfony\Component\Yaml\Yaml::parse
method is deprecated since version 2.2 and will be removed in 3.0. Pass
the YAML contents of the file instead.