### PR TITLE
SQLite Multiple Column Primary Key

### DIFF
--- a/src/Extensions/Database/DB/MetaData/Sqlite.php
+++ b/src/Extensions/Database/DB/MetaData/Sqlite.php
@@ -96,7 +96,7 @@ class PHPUnit_Extensions_Database_DB_MetaData_Sqlite extends PHPUnit_Extensions_
         while ($columnData = $statement->fetch(PDO::FETCH_NUM)) {
             $this->columns[$tableName][] = $columnData[1];
 
-            if ($columnData[5] == 1) {
+            if ((int)$columnData[5] !== 0) {
                 $this->keys[$tableName][] = $columnData[1];
             }
         }


### PR DESCRIPTION
When you have a primary key with multiple columns, getTablePrimaryKeys() only returns the first column, not all of them.  

This is due to line 99 which only checks for the value 1.  It's "0" when the column is not a part of the primary key, and the index inside the key otherwise.  So only the first column shows up because it's the only one with the value "1".

See: http://sqlite.org/pragma.html#pragma_table_info