### PR TITLE
Don't loose mysql FOREIGN_KEY_CHECKS status

### DIFF
--- a/src/Operation/Truncate.php
+++ b/src/Operation/Truncate.php
@@ -59,6 +59,7 @@ class Truncate implements Operation
     private function disableForeignKeyChecksForMysql(Connection $connection)
     {
         if ($this->isMysql($connection)) {
+            $connection->getConnection()->query('SET @PHPUNIT_OLD_FOREIGN_KEY_CHECKS = @@FOREIGN_KEY_CHECKS');
             $connection->getConnection()->query('SET FOREIGN_KEY_CHECKS = 0');
         }
     }
@@ -66,7 +67,7 @@ class Truncate implements Operation
     private function enableForeignKeyChecksForMysql(Connection $connection)
     {
         if ($this->isMysql($connection)) {
-            $connection->getConnection()->query('SET FOREIGN_KEY_CHECKS = 1');
+            $connection->getConnection()->query('SET FOREIGN_KEY_CHECKS=@PHPUNIT_OLD_FOREIGN_KEY_CHECKS');
         }
     }
 


### PR DESCRIPTION
Hi,

When truncate operation occurs on mysql database the FOREIGN_KEY_CHECKS is modified and when restored, it is set to an arbitrary ("1") value and the previous value is lost.

In some case we use this trick to allow phpunit to populate database from dataset without foreign key errors:

```php
protected function setUp()
    {
        $conn=$this->getConnection();
        $conn->getConnection()->query('set FOREIGN_KEY_CHECKS=0;');
        parent::setUp();
        $conn->getConnection()->query('set FOREIGN_KEY_CHECKS=1;');
    }
```

The truncate operations conflicts with this and this PR aims to fix that.

