### PR TITLE
Catch Base Level Exceptions for PDO Statement Executions

### DIFF
--- a/src/Operation/Replace.php
+++ b/src/Operation/Replace.php
@@ -93,7 +93,7 @@ class Replace extends RowBased
 
                         $insertStatement->execute($insertArgs);
                     }
-                } catch (Exception $e) {
+                } catch (\Exception $e) {
                     throw new Exception(
                         $this->operationName, $query, $args, $table, $e->getMessage()
                     );

--- a/src/Operation/RowBased.php
+++ b/src/Operation/RowBased.php
@@ -91,7 +91,7 @@ abstract class RowBased implements Operation
 
                 try {
                     $statement->execute($args);
-                } catch (Exception $e) {
+                } catch (\Exception $e) {
                     throw new Exception(
                         $this->operationName, $query, $args, $table, $e->getMessage()
                     );


### PR DESCRIPTION
This pull request resolves a small regression with DBUnit where the [base level `Exception` class](http://php.net/manual/en/class.exception.php) was no longer being caught during the `execute()` step of a `PDOStatement`. This is due to namespace conflicts with the `PHPUnit\DbUnit\Operation\Exception` class.

The fix will allow DBUnit to print out more useful exception messages when running into a `PDO` issue.

I've added a test for the `RowBased` operation only, but I'm open to adding a test for the `Replace` operation as well.