### PR TITLE
Remove a reference to the PDO object from the metaData property

### DIFF
--- a/src/Database/DefaultConnection.php
+++ b/src/Database/DefaultConnection.php
@@ -51,7 +51,7 @@ class DefaultConnection implements Connection
      */
     public function close()
     {
-        unset($this->connection);
+        unset($this->connection, $this->metaData);
     }
 
     /**


### PR DESCRIPTION
Fix for [issue #203](https://github.com/sebastianbergmann/dbunit/issues/203) the `DefaultConnection::close()` does not close a connection.