### PR TITLE
Show better error when number of columns differ for csv dataset

### DIFF
--- a/src/DataSet/CsvDataSet.php
+++ b/src/DataSet/CsvDataSet.php
@@ -76,6 +76,7 @@ class CsvDataSet extends AbstractDataSet
 
         $fh      = \fopen($csvFile, 'r');
         $columns = $this->getCsvRow($fh);
+        $columnsCount = count($columns);
 
         if ($columns === false) {
             throw new InvalidArgumentException("Could not determine the headers from the given file {$csvFile}");
@@ -84,8 +85,13 @@ class CsvDataSet extends AbstractDataSet
         $metaData = new DefaultTableMetadata($tableName, $columns);
         $table    = new DefaultTable($metaData);
 
+        $rowNumber = 1;
         while (($row = $this->getCsvRow($fh)) !== false) {
+            if ($columnsCount !== count($row)) {
+                throw new InvalidArgumentException("Row no. {$rowNumber} in csv file {$csvFile} should have an equal number of elements as table {$tableName}");
+            }
             $table->addRow(\array_combine($columns, $row));
+            $rowNumber++;
         }
 
         $this->tables[$tableName] = $table;


### PR DESCRIPTION
I think that it would be great if in class PHPUnit_Extensions_Database_DataSet_CsvDataSet will be check that parameters passing to function array_combine have equal number of elements. Sometimes happen that they differ and developer do not know in which file and line is the problem.