### PR TITLE
Return type of DefaultConnection::createQueryTable should match return type of Connection::createQueryTable

### DIFF
--- a/src/Database/DefaultConnection.php
+++ b/src/Database/DefaultConnection.php
@@ -14,6 +14,7 @@ use PDO;
 use PHPUnit\DbUnit\Database\Metadata\AbstractMetadata;
 use PHPUnit\DbUnit\Database\Metadata\Metadata;
 use PHPUnit\DbUnit\DataSet\IDataSet;
+use PHPUnit\DBUnit\DataSet\ITable;
 use PHPUnit\DbUnit\DataSet\QueryTable;
 
 /**
@@ -101,7 +102,7 @@ class DefaultConnection implements Connection
      * @param string $resultName
      * @param string $sql
      *
-     * @return Table
+     * @return ITable
      */
     public function createQueryTable($resultName, $sql)
     {


### PR DESCRIPTION
As the title suggests, `Connection` declares `createQueryTable` to return an `ITable` whereas `DefaultConnect::createQueryTable` has docs to return `Table`.

This has tripped me up when I have strict typing enabled and the return type should have been an `ITable`, not a `Table`.